### PR TITLE
feat(backend): Use VecDeque instead of SlicedDeque

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-slice-deque"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 authors = ["danielsanchezq <sanchez.quiros.daniel@gmail.com>"]
 edition = "2021"
 license-file = "License"
@@ -24,4 +24,3 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slice-deque = "0.3"

--- a/src/drain_filter.rs
+++ b/src/drain_filter.rs
@@ -1,0 +1,46 @@
+use crate::FixedSliceDeque;
+
+/// An iterator that filters elements and removes them from the deque.
+pub struct DrainFilter<'a, T, F>
+where
+    F: FnMut(&mut T) -> bool,
+{
+    pub(crate) deque: &'a mut FixedSliceDeque<T>,
+    pub(crate) filter: F,
+    pub(crate) old_len: usize,
+    pub(crate) idx: usize,
+    pub(crate) del: usize,
+}
+
+impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
+where
+    F: FnMut(&mut T) -> bool,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        while self.idx < self.old_len {
+            let i = self.idx;
+            self.idx += 1;
+            let current_idx = i - self.del;
+            if (self.filter)(&mut self.deque.buffer[current_idx]) {
+                self.del += 1;
+                return self.deque.buffer.remove(current_idx);
+            }
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.old_len - self.idx))
+    }
+}
+
+impl<'a, T, F> Drop for DrainFilter<'a, T, F>
+where
+    F: FnMut(&mut T) -> bool,
+{
+    fn drop(&mut self) {
+        while self.next().is_some() {}
+    }
+}


### PR DESCRIPTION
I'm replacing `SliceDequeue` for `VecDequeue` as the former is kinda deprecated.